### PR TITLE
AQCU-1765: remove time from qualifier start and end dates when they are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Initial release - happy path.
 
-[Unreleased]: https://github.com/USGS-CIDA/aqcu-ext-report/compare/master...master
+### Changed
+- AQ Qualifiers remapped to Extremes report-specific Qualifier model
+- Qualifiers for daily value timeseries have time removed from date
+
+## [0.0.1] - 2019-03-01
+### Added
+- Initial release - happy path
+- Specific timeout values
+- Default Aquarius timeout value of 30000
+
+### Changed
+- Simplified extremes logic
+- Use streams() instead of loops, where possible
+- Aquarius SDK verson 18.8.1
+- AQCU Framework version 0.0.5
+
+### Removed
+- Disabled TLS 1.0/1.1 by default.
+
+[Unreleased]: https://github.com/USGS-CIDA/aqcu-ext-report/compare/aqcu-ext-report-0.0.1...master

--- a/src/main/java/gov/usgs/aqcu/builder/ReportBuilderService.java
+++ b/src/main/java/gov/usgs/aqcu/builder/ReportBuilderService.java
@@ -71,7 +71,7 @@ public class ReportBuilderService {
 			primaryMinMax = minMaxBuilderService.findMinMaxPoints(primaryData.getPoints());
 			primaryOutput.setMaxPoints(getExtremesPoints(primaryMinMax.getMaxPoints(), primaryIsDaily, primaryZoneOffset));
 			primaryOutput.setMinPoints(getExtremesPoints(primaryMinMax.getMinPoints(), primaryIsDaily, primaryZoneOffset));
-			primaryOutput.setQualifiers(primaryData.getQualifiers());
+			primaryOutput.setQualifiers(getExtremesQualifiers(primaryData.getQualifiers(), primaryIsDaily, primaryZoneOffset));
 			qualifiers.addAll(primaryData.getQualifiers());
 		}
 
@@ -89,7 +89,7 @@ public class ReportBuilderService {
 				TimeSeriesMinMax upchainMinMax = minMaxBuilderService.findMinMaxPoints(upchainData.getPoints());
 				upchainOutput.setMaxPoints(getExtremesPoints(upchainMinMax.getMaxPoints(), upchainIsDaily, upchainZoneOffset));
 				upchainOutput.setMinPoints(getExtremesPoints(upchainMinMax.getMinPoints(), upchainIsDaily, upchainZoneOffset));
-				upchainOutput.setQualifiers(upchainData.getQualifiers());
+				upchainOutput.setQualifiers(getExtremesQualifiers(upchainData.getQualifiers(), upchainIsDaily, upchainZoneOffset));
 				qualifiers.addAll(upchainData.getQualifiers());
 
 				// Find related data
@@ -130,7 +130,7 @@ public class ReportBuilderService {
 				TimeSeriesMinMax derivedMinMax = minMaxBuilderService.findMinMaxPoints(derivedData.getPoints());
 				derviedOutput.setMaxPoints(getExtremesPoints(derivedMinMax.getMaxPoints(), true, derviedZoneOffset));
 				derviedOutput.setMinPoints(getExtremesPoints(derivedMinMax.getMinPoints(), true, derviedZoneOffset));
-				derviedOutput.setQualifiers(derivedData.getQualifiers());
+				derviedOutput.setQualifiers(getExtremesQualifiers(derivedData.getQualifiers(), true, derviedZoneOffset));
 				qualifiers.addAll(derivedData.getQualifiers());
 			}
 		}
@@ -154,6 +154,13 @@ public class ReportBuilderService {
 	protected List<ExtremesPoint> getExtremesPoints(List<TimeSeriesPoint> points, Boolean isDaily, ZoneOffset zoneOffset) {
 		if(points != null && !points.isEmpty()) {
 			return points.stream().map(p -> new ExtremesPoint(p, isDaily, zoneOffset)).collect(Collectors.toList());
+		}
+		return new ArrayList<>();
+	}
+	
+	protected List<ExtremesQualifier> getExtremesQualifiers(List<Qualifier> quals, Boolean isDaily, ZoneOffset zoneOffset) {
+		if(quals != null && !quals.isEmpty()) {
+			return quals.stream().map(q -> new ExtremesQualifier(q, isDaily, zoneOffset)).collect(Collectors.toList());
 		}
 		return new ArrayList<>();
 	}
@@ -200,4 +207,5 @@ public class ReportBuilderService {
 		
 		return metadata;
 	}
+
 }

--- a/src/main/java/gov/usgs/aqcu/model/ExtremesMinMax.java
+++ b/src/main/java/gov/usgs/aqcu/model/ExtremesMinMax.java
@@ -4,14 +4,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.Qualifier;
-
 public class ExtremesMinMax {
 	public static final String MIN_MAX_POINTS_KEY = "points";
 
 	private Map<String, List<ExtremesPoint>> min;
 	private Map<String, List<ExtremesPoint>> max;
-	private List<Qualifier> qualifiers;
+	private List<ExtremesQualifier> qualifiers;
 	
 	public Map<String, List<ExtremesPoint>> getMin() {
 		return min;
@@ -29,11 +27,11 @@ public class ExtremesMinMax {
 		this.max = val;
 	}
 	
-	public List<Qualifier> getQualifiers() {
+	public List<ExtremesQualifier> getQualifiers() {
 		return qualifiers;
 	}
 	
-	public void setQualifiers(List<Qualifier> val) {
+	public void setQualifiers(List<ExtremesQualifier> val) {
 		this.qualifiers = val;
 	}
 

--- a/src/main/java/gov/usgs/aqcu/model/ExtremesQualifier.java
+++ b/src/main/java/gov/usgs/aqcu/model/ExtremesQualifier.java
@@ -1,0 +1,69 @@
+package gov.usgs.aqcu.model;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
+
+import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.Qualifier;
+
+/** 
+ * This class is a substitute for com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.Qualifier
+ * Extremes requires Qualifier that:
+ * a) Have an optional time component to the temporal value;
+ */
+public class ExtremesQualifier {
+	private String identifier;
+	private Temporal startTime;
+	private Temporal endTime;
+	
+
+	public ExtremesQualifier() {};
+
+	public ExtremesQualifier(Qualifier source, Boolean isDaily, ZoneOffset zoneOffset) {
+		if(source.getStartTime() != null) {
+			if (isDaily) {
+				setStartTime(LocalDateTime.ofInstant(source.getStartTime(), zoneOffset).toLocalDate());
+			} else {
+				setStartTime(source.getStartTime());
+			}
+		}
+		if(source.getEndTime() != null) {
+			if (isDaily) {
+			setEndTime(LocalDateTime.ofInstant(source.getEndTime(), zoneOffset).toLocalDate());
+			} else {
+				setEndTime(source.getEndTime());
+			}
+		}
+
+		if(source.getIdentifier() != null) {
+			setIdentifier(source.getIdentifier());
+		}
+	}
+
+	public Temporal getStartTime() {
+		return startTime;
+	}
+
+	public ExtremesQualifier setStartTime(Temporal startTime) {
+		this.startTime = startTime;
+		return this;
+	}
+
+	public Temporal getEndTime() {
+		return endTime;
+	}
+
+	public ExtremesQualifier setEndTime(Temporal endTime) {
+		this.endTime = endTime;
+		return this;
+	}
+	
+	public String getIdentifier() {
+		return identifier;
+	}
+
+	public ExtremesQualifier setIdentifier(String identifier) {
+		this.identifier = identifier;
+		return this;
+	}
+}

--- a/src/test/java/gov/usgs/aqcu/builder/ReportBuilderServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/builder/ReportBuilderServiceTest.java
@@ -158,20 +158,12 @@ public class ReportBuilderServiceTest {
 				.setNumeric(1.0D)
 			)
 	));
-	private ArrayList<Qualifier> quals1 = new ArrayList<>(Arrays.asList(
-		new Qualifier()
-			.setIdentifier("qual1"),
-		new Qualifier()
-			.setIdentifier("qual2")
-	));
-	private ArrayList<Qualifier> quals2 = new ArrayList<>(Arrays.asList(
-		new Qualifier()
-			.setIdentifier("qual1")
-	));
-	private ArrayList<Qualifier> quals3 = new ArrayList<>(Arrays.asList(
-		new Qualifier()
-			.setIdentifier("qual3")
-	));
+	private Qualifier qual1 = new Qualifier().setIdentifier("qual1");
+	private Qualifier qual2 = new Qualifier().setIdentifier("qual2");
+	private Qualifier qual3 = new Qualifier().setIdentifier("qual3");
+	private ArrayList<Qualifier> quals1 = new ArrayList<>();
+	private ArrayList<Qualifier> quals2 = new ArrayList<>();
+	private ArrayList<Qualifier> quals3 = new ArrayList<>();
 	private HashMap<String, QualifierMetadata> qualMetadata;
 
 	@Before
@@ -182,6 +174,12 @@ public class ReportBuilderServiceTest {
 		requestParameters.setStartDate(LocalDate.parse("2018-01-01"));
 		requestParameters.setEndDate(LocalDate.parse("2018-02-01"));
 		requestParameters.setPrimaryTimeseriesIdentifier("primaryTsId");
+		qual1.setEndTime(Instant.parse("2018-01-03T00:00:00Z"));
+		qual2.setEndTime(Instant.parse("2018-02-04T00:00:00Z"));
+		qual3.setEndTime(Instant.parse("2018-03-05T00:00:00Z"));
+		quals1.addAll(Arrays.asList(qual1,qual2));
+		quals2.addAll(Arrays.asList(qual1));
+		quals3.addAll(Arrays.asList(qual3));
 		qualMetadata = new HashMap<>();
 		qualMetadata.put("qual1", new QualifierMetadata().setIdentifier("qual1"));
 		qualMetadata.put("qual2", new QualifierMetadata().setIdentifier("qual2"));
@@ -235,6 +233,8 @@ public class ReportBuilderServiceTest {
 		assertEquals(result.getPrimary().getMax().get(ReportBuilderService.UPCHAIN_RELATED_KEY).get(0).getValue(), BigDecimal.valueOf(1.0D));
 		assertEquals(result.getPrimary().getMax().get(ReportBuilderService.UPCHAIN_RELATED_KEY).get(1).getValue(), BigDecimal.valueOf(3.0D));
 		assertNull(result.getPrimary().getMin().get(ReportBuilderService.UPCHAIN_RELATED_KEY));
+		assertEquals(Instant.parse("2018-01-03T00:00:00Z"), result.getPrimary().getQualifiers().get(0).getEndTime());
+		assertEquals(Instant.parse("2018-02-04T00:00:00Z"), result.getPrimary().getQualifiers().get(1).getEndTime());
 
 		// Verify Upchain Data
 		assertEquals(result.getUpchain().getMax().keySet().size(), 2);
@@ -247,6 +247,7 @@ public class ReportBuilderServiceTest {
 		assertEquals(result.getUpchain().getMax().get(ReportBuilderService.PRIMARY_RELATED_KEY).get(0).getValue(), BigDecimal.valueOf(2.0D));
 		assertEquals(result.getUpchain().getMin().get(ReportBuilderService.PRIMARY_RELATED_KEY).size(), 1);
 		assertEquals(result.getUpchain().getMin().get(ReportBuilderService.PRIMARY_RELATED_KEY).get(0).getValue(), BigDecimal.valueOf(1.0D));
+		assertEquals(Instant.parse("2018-01-03T00:00:00Z"), result.getUpchain().getQualifiers().get(0).getEndTime());
 
 		// Verify Derived Data
 		assertEquals(result.getDv().getMax().keySet().size(), 1);
@@ -257,6 +258,7 @@ public class ReportBuilderServiceTest {
 		assertEquals(result.getDv().getMin().get(ExtremesMinMax.MIN_MAX_POINTS_KEY).size(), 1);
 		assertEquals(result.getDv().getMin().get(ExtremesMinMax.MIN_MAX_POINTS_KEY).get(0).getValue(), BigDecimal.valueOf(1.0D));
 		assertEquals(result.getDv().getMin().get(ExtremesMinMax.MIN_MAX_POINTS_KEY).get(0).getTime(), LocalDate.parse("2018-01-01"));
+		assertEquals(LocalDate.parse("2018-03-05"), result.getDv().getQualifiers().get(0).getEndTime());
 
 		// Verify Metadata
 		assertEquals(result.getReportMetadata().getTitle(), ReportBuilderService.REPORT_TITLE);

--- a/src/test/java/gov/usgs/aqcu/model/ExtremesQualifierTest.java
+++ b/src/test/java/gov/usgs/aqcu/model/ExtremesQualifierTest.java
@@ -1,0 +1,63 @@
+package gov.usgs.aqcu.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import com.aquaticinformatics.aquarius.sdk.timeseries.servicemodels.Publish.Qualifier;
+
+import org.junit.Test;
+
+public class ExtremesQualifierTest {
+    
+	private Instant startTime = Instant.parse("2000-01-02T09:32:00Z");
+	private Instant endTime = Instant.parse("2000-01-03T09:32:00Z");
+    private Qualifier qualifier;
+
+	@Test
+	public void constructorTestFull() {
+		qualifier = new Qualifier().setIdentifier("TESTQUALIFIER");
+		qualifier.setStartTime(startTime);
+		qualifier.setEndTime(endTime);
+        ExtremesQualifier testQualifier = new ExtremesQualifier(qualifier, true, ZoneOffset.UTC);
+        assertEquals(LocalDate.parse("2000-01-02"), testQualifier.getStartTime());
+        assertEquals(LocalDate.parse("2000-01-03"), testQualifier.getEndTime());
+        assertEquals("TESTQUALIFIER", testQualifier.getIdentifier());
+        testQualifier = new ExtremesQualifier(qualifier, false, ZoneOffset.UTC);
+        assertEquals(startTime, testQualifier.getStartTime());
+        assertEquals(endTime, testQualifier.getEndTime());
+        assertEquals("TESTQUALIFIER", testQualifier.getIdentifier());
+    }
+
+	@Test
+	public void constructorTestNoTime() {
+		qualifier = new Qualifier().setIdentifier("TESTQUALIFIER");
+		ExtremesQualifier testQualifier = new ExtremesQualifier(qualifier, true, ZoneOffset.UTC);
+        assertNull(testQualifier.getStartTime());
+        assertNull(testQualifier.getEndTime());
+        assertEquals("TESTQUALIFIER", testQualifier.getIdentifier());
+    }
+
+	@Test
+	public void constructorTestNoIdentifier() {
+		qualifier = new Qualifier();
+		qualifier.setStartTime(startTime);
+		qualifier.setEndTime(endTime);
+		ExtremesQualifier testQualifier = new ExtremesQualifier(qualifier, true, ZoneOffset.UTC);
+		assertEquals(LocalDate.parse("2000-01-02"), testQualifier.getStartTime());
+        assertEquals(LocalDate.parse("2000-01-03"), testQualifier.getEndTime());
+        assertNull(testQualifier.getIdentifier());
+    }
+
+	@Test
+	public void constructorTestNoTimeOrValue() {
+		qualifier = new Qualifier();
+		ExtremesQualifier testQualifier = new ExtremesQualifier(qualifier, true, ZoneOffset.UTC);
+        assertNull(testQualifier.getStartTime());
+        assertNull(testQualifier.getEndTime());
+        assertNull(testQualifier.getIdentifier());
+    }
+}


### PR DESCRIPTION
attached to a daily value timeseries.

This will allow repgen to properly match qualifiers with daily value
min/max values.